### PR TITLE
修复issue#60的问题，另外还有个问题你看下描述

### DIFF
--- a/app/autoGroupName.js
+++ b/app/autoGroupName.js
@@ -139,14 +139,14 @@ export class autoGroupName extends plugin {
     if (!config.enable) return false
     switch (config.mode) {
       case 1:
-        if (!TodoGroup) {
+        if (!TodoGroup || TodoGroup.length === 0) {
           TodoGroup = this.taskGroup
           SaveSuffix = await this.getSuffixFun()
         }
         await this.setGroupCard(TodoGroup.shift(), SaveSuffix)
         break
       case 2:
-        if (!TodoGroup) {
+        if (!TodoGroup || TodoGroup.length === 0) {
           TodoGroup = this.taskGroup
         }
         let Suffix = await this.getSuffixFun()


### PR DESCRIPTION
我发现用锅巴插件进行配置时有点问题，但是我没找到在哪里改，锅巴插件开发确实没做过，该问题导致：
我先执行【#切换名片样式1,2,3,4,7,12,13,14,15】，此时我config里的autoGroupName.yaml的active修改为：
active:
  - B站热搜
  - GenshinVersionDay
  - HotSearch
  - MemoryPercent
  - StarRailVersionDay
  - 今日头条热搜
  - 抖音热搜
  - 百度热搜
  - 知乎热搜
 此时如果我在锅巴插件修改了“群名片更新模式”，从0更新到1，点击保存，保存后autoGroupName.yaml里的mode确实更新成1了，但是active会被同时更新为默认的这三个：
active:
  - "MemoryPercent"
  - "SystemTime"
  - "GenshinVersionDay"
 我之前的名片样式就丢失了，导致我又需要在群里手动执行一次【#切换名片样式1,2,3,4,7,12,13,14,15】