### PR TITLE
本插件涉及到的定时任务调整为启用该功能后才创建

### DIFF
--- a/app/autoGroupName.js
+++ b/app/autoGroupName.js
@@ -7,6 +7,7 @@ import path from 'path'
 import fs from 'fs'
 import puppeteer from '../../../lib/puppeteer/puppeteer.js'
 import { headStyle } from '../model/base.js'
+import PluginsLoader from "../../../lib/plugins/loader.js";
 
 let TodoGroup = []
 let SaveSuffix = ''
@@ -33,13 +34,19 @@ export class autoGroupName extends plugin {
       } // ,{ reg: '打印群名片', fnc: 'sendNameCard' }
       ]
     })
-    this.task = {
-      cron: this.appConfig.cron,
-      name: '自动群名片',
-      fnc: () => this.CardTask()
-    }
     Object.defineProperty(this.task, 'log', { get: () => false })
   }
+
+    async init() {
+        // 功能关闭时，不创建任务，减轻任务表内容
+        if (this.appConfig.enable) {
+            PluginsLoader.task.push({
+                cron: this.appConfig.cron,
+                name: '自动群名片',
+                fnc: () => this.CardTask()
+            })
+        }
+    }
 
   // 开发时使用，立刻打印全部模块提供的群名片
   async sendNameCard () {

--- a/app/autoSendUpdateLog.js
+++ b/app/autoSendUpdateLog.js
@@ -2,7 +2,7 @@ import plugin from '../../../lib/plugins/plugin.js'
 import setting from "../model/setting.js";
 import common from "../../../lib/common/common.js";
 import cfg from "../../../lib/config/config.js";
-
+import PluginsLoader from "../../../lib/plugins/loader.js";
 
 export class autoSendUpdateLog extends plugin {
   constructor () {
@@ -20,11 +20,6 @@ export class autoSendUpdateLog extends plugin {
         fnc: "updataLog",
       },rule],
     })
-    this.task = {
-      cron: '0 58 7 * * ?',
-      name: '自动化插件_早晨推送更新消息',
-      fnc: () => this.updataTask()
-    }
     this.islog = false
     Object.defineProperty(rule, 'log', { get: () => this.islog })
   }
@@ -34,6 +29,14 @@ export class autoSendUpdateLog extends plugin {
   }
 
   async init () {
+      // 日志提醒模式为“0-不提醒”时，不创建任务，减轻任务表内容
+      if (this.appconfig.log !== 0) {
+          PluginsLoader.task.push({
+              cron: '0 58 7 * * ?',
+              name: '自动化插件_早晨推送更新消息',
+              fnc: () => this.updataTask()
+          })
+      }
     if (!this.appconfig.remind) {return}
 
     let key = `Yz:loginMsg:${Bot.uin}`

--- a/app/autoSign.js
+++ b/app/autoSign.js
@@ -1,6 +1,7 @@
 import plugin from "../../../lib/plugins/plugin.js";
 import fetch from "node-fetch";
 import setting from "../model/setting.js";
+import PluginsLoader from "../../../lib/plugins/loader.js";
 
 export class autoSign extends plugin {
   constructor() {
@@ -14,12 +15,18 @@ export class autoSign extends plugin {
         fnc: "autoSign",
       }],
     });
-    this.task = {
-      cron: this.appconfig.cron,
-      name: "自动化插件_签名和说说",
-      fnc: () => this.autoSign(),
-    };
   }
+
+    async init() {
+        // 功能关闭时，不创建任务，减轻任务表内容
+        if (this.appconfig.enable) {
+            PluginsLoader.task.push({
+                cron: this.appconfig.cron,
+                name: "自动化插件_签名和说说",
+                fnc: () => this.autoSign(),
+            })
+        }
+    }
 
   // 获取配置
   get appconfig () {

--- a/app/autoStrategy.js
+++ b/app/autoStrategy.js
@@ -7,6 +7,7 @@ import gsCfg from "../../genshin/model/gsCfg.js";
 import path from "path";
 import { _path } from "../model/path.js";
 import setting from "../model/setting.js";
+import PluginsLoader from "../../../lib/plugins/loader.js";
 
 let packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'))
 const isMiao = packageJson.name === 'miao-yunzai'
@@ -39,12 +40,18 @@ export class autoStrategy extends plugin {
       [341523]
     ]
     this.oss = '?x-oss-process=image//resize,s_1200/quality,q_90/auto-orient,0/interlace,1/format,jpg'
-    this.task = {
-      cron: this.appconfig.cron,
-      name: "自动化插件_更新默认攻略",
-      fnc: () => this.UpdateTask(),
-    };
   }
+
+    async init() {
+        // 功能关闭时，不创建任务，减轻任务表内容
+        if (this.appconfig.enable) {
+            PluginsLoader.task.push({
+                cron: this.appconfig.cron,
+                name: "自动化插件_更新默认攻略",
+                fnc: () => this.UpdateTask(),
+            })
+        }
+    }
 
   get appconfig () {
     return setting.getConfig("autoStrategy");

--- a/app/autoWebSocketTask.js
+++ b/app/autoWebSocketTask.js
@@ -21,10 +21,11 @@ export class autoWebSocketTask extends plugin {
     }
 
     async init() {
-        // 延迟半分钟启动，确保yunzai已连接到协议端，可根据自己实际情况调整（如果你的yunzai半分钟内都无法启动，可以延长这里的延迟时间）
+        // 默认延迟30秒启动，确保yunzai已连接到协议端，可根据自己实际情况调整（如果你的yunzai在30秒内都无法启动，可以在taskManage.yaml中延长这里的延迟时间）
+        let wsDelayTime = this.appConfig.wsDelayTime ? this.appConfig.wsDelayTime : 30
         setTimeout(() => {
             this.startWSTaskBatch()
-        }, 30 * 1000)
+        }, wsDelayTime * 1000)
     }
 
     // 获取配置
@@ -72,10 +73,11 @@ export class autoWebSocketTask extends plugin {
             if (!cfg.bot.online_msg_exp) {
                 return
             }
-            const key = `Yz:loginMsg:${Bot.uin}`
+            const key = `Yz:AutoPlugin:WSLog:${Bot.uin}`
             if (await redis.get(key)) {
                 return
             }
+            await redis.set(key, '1', { EX: cfg.bot.online_msg_exp })
             let massage = []
             for (let msg of logArray) {
                 massage.push({

--- a/def/taskManage.yaml
+++ b/def/taskManage.yaml
@@ -2,6 +2,8 @@
 openWS: false
 # openWS开启后，填写应用的WebSocket连接地址（必填）
 ws: 'ws://localhost:2536/OneBotv11'
+# 延迟30秒启动，确保yunzai已连接到协议端，可根据自己实际情况调整（如果你的yunzai在30秒内都无法启动，可以延长这里的延迟时间）
+wsDelayTime: 30
 
 list:
   - task:


### PR DESCRIPTION
我发现当配置文件中“是否启用该功能”配置为false时，插件仍然会启动一个定时任务，此时不仅让任务表内容增多，还增加了系统线程，系统要额外处理这些“假”的定时任务。基于这一点，只有配置文件里启用该功能，才往task列表中添加对应的任务。

此外调整了一下autoWebSocketTask.js的内容